### PR TITLE
Fix for header that doesn't contain GN= or PE= in sport database

### DIFF
--- a/src/sprot.py
+++ b/src/sprot.py
@@ -46,7 +46,7 @@ def get_fasta_info(fasta_file):
                 i += 1
             product = " ".join(words[1:i])
             #loop through the words till we find "GN=" or "PE=". We are assuming "PE=" comes immediately after "GN=" so if we hit "PE=" first, then the gene name doesn't exist. We also assume the gene name is one word
-            while (words[i].find("GN=") == -1 and words[i].find("PE=") == -1) or (i+1 != len(words)):
+            while (words[i].find("GN=") == -1 and words[i].find("PE=") == -1) or (i+1 < len(words)):
                 i += 1
             if not words[i].find("GN=") == -1: #if gene name exists
                 name = words[i][3:] #the "[3:]" is to get rid of the "GN=" in the beginning

--- a/src/sprot.py
+++ b/src/sprot.py
@@ -46,7 +46,7 @@ def get_fasta_info(fasta_file):
                 i += 1
             product = " ".join(words[1:i])
             #loop through the words till we find "GN=" or "PE=". We are assuming "PE=" comes immediately after "GN=" so if we hit "PE=" first, then the gene name doesn't exist. We also assume the gene name is one word
-            while words[i].find("GN=") == -1 and words[i].find("PE=") == -1:
+            while (words[i].find("GN=") == -1 and words[i].find("PE=") == -1) or (i+1 != len(words)):
                 i += 1
             if not words[i].find("GN=") == -1: #if gene name exists
                 name = words[i][3:] #the "[3:]" is to get rid of the "GN=" in the beginning

--- a/src/sprot.py
+++ b/src/sprot.py
@@ -46,7 +46,7 @@ def get_fasta_info(fasta_file):
                 i += 1
             product = " ".join(words[1:i])
             #loop through the words till we find "GN=" or "PE=". We are assuming "PE=" comes immediately after "GN=" so if we hit "PE=" first, then the gene name doesn't exist. We also assume the gene name is one word
-            while (words[i].find("GN=") == -1 and words[i].find("PE=") == -1) or (i+1 < len(words)):
+            while (words[i].find("GN=") == -1 and words[i].find("PE=") == -1) and (i+1 < len(words)):
                 i += 1
             if not words[i].find("GN=") == -1: #if gene name exists
                 name = words[i][3:] #the "[3:]" is to get rid of the "GN=" in the beginning


### PR DESCRIPTION
In the last Swissprot database I dowloaded there is some cases where the sequence headers don't have GN= or PE=. Consequently I get this error:
  File "/home/jacda119/git/Annie/src/sprot.py", line 49, in get_fasta_info
    while words[i].find("GN=") == -1 and words[i].find("PE=") == -1:
IndexError: list index out of range.

I propose a simple fix to not goes over the word table index.
