### PR TITLE
Add possibility to retrieve terms from Pathway db

### DIFF
--- a/src/ipr.py
+++ b/src/ipr.py
@@ -12,8 +12,8 @@ def read_ipr(io_buffer, whitelist=None):
         columns = line.split("\t") #columns are assumed to be tab-separated
         #if column exists and dbxref is in whitelist (aside from whitespace padding and caps)
         if (len(columns)>3 and (columns[3].strip().lower() in whitelist)) or\
-		 (len(columns)>3 and not whitelist): 
-	    ipr_list.append(Annotation(columns[0].strip(), "Dbxref", columns[3].strip().upper()+":"+columns[4].strip()))
+		 (len(columns)>3 and not whitelist):
+            ipr_list.append(Annotation(columns[0].strip(), "Dbxref", columns[3].strip().upper()+":"+columns[4].strip()))
         #if column exists (we don't care about the whitelist for GO annotations)
         if len(columns)>13 and columns[13].find("GO:") != -1: 
             ipr_list.append(Annotation(columns[0].strip(), "Dbxref", columns[13].strip()))

--- a/src/ipr.py
+++ b/src/ipr.py
@@ -12,14 +12,20 @@ def read_ipr(io_buffer, whitelist=None):
         columns = line.split("\t") #columns are assumed to be tab-separated
         #if column exists and dbxref is in whitelist (aside from whitespace padding and caps)
         if (len(columns)>3 and (columns[3].strip().lower() in whitelist)) or\
-                (len(columns)>3 and not whitelist): 
-            ipr_list.append(Annotation(columns[0].strip(), "Dbxref", columns[3].strip().upper()+":"+columns[4].strip()))
+		 (len(columns)>3 and not whitelist): 
+	    ipr_list.append(Annotation(columns[0].strip(), "Dbxref", columns[3].strip().upper()+":"+columns[4].strip()))
         #if column exists (we don't care about the whitelist for GO annotations)
         if len(columns)>13 and columns[13].find("GO:") != -1: 
             ipr_list.append(Annotation(columns[0].strip(), "Dbxref", columns[13].strip()))
         #if column exists (we don't care about the whitelist for IPR annotations)
         if len(columns)>11 and columns[11].find("IPR") != -1: 
             ipr_list.append(Annotation(columns[0].strip(), "Dbxref", "InterPro:"+columns[11].strip()))
+	if len(columns)>14 :  #if column exists 
+            list_col_14=columns[14].split('|')
+            for element in list_col_14:
+                db_current=element.rsplit(':', 1)[0]
+                if db_current.strip().lower() in whitelist:
+                    ipr_list.append(Annotation(columns[0].strip(), "Dbxref", element.strip()))
 
     #this alg removes duplicates
     ipr_list = sorted(ipr_list)

--- a/src/sprot.py
+++ b/src/sprot.py
@@ -45,13 +45,14 @@ def get_fasta_info(fasta_file):
             while words[i].find("OS=") == -1: 
                 i += 1
             product = " ".join(words[1:i])
-            #loop through the words till we find "GN=" or "PE=". We are assuming "PE=" comes immediately after "GN=" so if we hit "PE=" first, then the gene name doesn't exist. We also assume the gene name is one word
-            while (words[i].find("GN=") == -1 and words[i].find("PE=") == -1) and (i+1 < len(words)):
+            #loop through the words till we find "GN=" or reach the end of the line
+            while (words[i].find("GN=") == -1 ) and (i+1 < len(words)):
                 i += 1
             if not words[i].find("GN=") == -1: #if gene name exists
                 name = words[i][3:] #the "[3:]" is to get rid of the "GN=" in the beginning
-            else: #if gene name doesn't exist, use part of the dbxref for the name
-                name = ref.split("|")[2].split("_")[0]
+		name=name.rstrip()
+	    else: #if gene name doesn't exist, use part of the dbxref for the name
+		name = ref.split("|")[2].split("_")[0]
             #add to dictionary
             dbxrefs[ref] = (product,name)
     return dbxrefs


### PR DESCRIPTION
I was trying to retrieve information from Pathway Db (KEGG,MetaCyc...) that are present in last columns of Interproscan outputs. 
Even if the DBs were present in the WhiteList, the information present over the 13th column were not taken in account.
The fix checks all column over the 13th and if one of the element of the whitelist is present in those columns, we report the value in the output (We create a new DBxref element).
